### PR TITLE
Drupal Core patch not needed anymore as issue #3230541 is now fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,15 +39,18 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "drupal/core-composer-scaffold": true,
+            "oomphinc/composer-installers-extender": true,
+            "drupal/core-project-message": true
+        }
     },
     "extra": {
         "enable-patching": true,
-        "patches": {
-            "drupal/core": {
-                "3230541: Fix queue items not being leased by cron for proper time segments": "https://www.drupal.org/files/issues/2022-02-16/3230541-11.diff"
-            }
-        },
         "drupal-scaffold": {
             "locations": {
                 "web-root": "docroot/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "013b11de111abd0cccdc6eb9d01ffd4d",
+    "content-hash": "9d29953428d364f0c0e21b34ca931e5a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1339,12 +1339,12 @@
                     "role": "Maintainer"
                 },
                 {
-                    "name": "fethi.krout",
-                    "homepage": "https://www.drupal.org/user/3206765"
-                },
-                {
                     "name": "matio89",
                     "homepage": "https://www.drupal.org/user/2320090"
+                },
+                {
+                    "name": "Musa.thomas",
+                    "homepage": "https://www.drupal.org/user/1213824"
                 },
                 {
                     "name": "romainj",
@@ -2169,12 +2169,8 @@
                     "homepage": "https://www.drupal.org/u/graber"
                 },
                 {
-                    "name": "Jon Pugh",
-                    "homepage": "https://www.drupal.org/user/17028"
-                },
-                {
-                    "name": "bojanz",
-                    "homepage": "https://www.drupal.org/user/86106"
+                    "name": "Graber",
+                    "homepage": "https://www.drupal.org/user/1599440"
                 },
                 {
                     "name": "infojunkie",
@@ -2183,6 +2179,10 @@
                 {
                     "name": "joelpittet",
                     "homepage": "https://www.drupal.org/user/160302"
+                },
+                {
+                    "name": "Jon Pugh",
+                    "homepage": "https://www.drupal.org/user/17028"
                 }
             ],
             "description": "Adds an ability to perform bulk operations on selected entities from view results. Provides an API to create such operations.",
@@ -5543,6 +5543,7 @@
                     "type": "tidelift"
                 }
             ],
+            "abandoned": "symfony/error-handler",
             "time": "2021-09-24T13:30:14+00:00"
         },
         {
@@ -12105,5 +12106,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Der Drupal Core Patch von https://www.drupal.org/node/3230541 wird nicht mehr gebraucht. Der ist mittlerweile (9.3.x und höher) in Drupal Core enthalten.

Habe außerdem noch ein composer update --lock gemacht, das hat noch ein paar (marginale) Änderungen in composer.lock verursacht. Außerdem noch die "allow-plugins"-Sektion die mit composer 2.2 kommt.